### PR TITLE
Products carousel UI tweaks

### DIFF
--- a/packages/shop-minis-ui-extensions/src/extensions/bundle-products-carousel/components/ProductsCarouselCard.tsx
+++ b/packages/shop-minis-ui-extensions/src/extensions/bundle-products-carousel/components/ProductsCarouselCard.tsx
@@ -19,11 +19,14 @@ export interface ProductsCarouselProduct extends ProductCardProduct {
   defaultVariant: ProductsCarouselProductVariant
 }
 
+const CAROUSEL_CARD_DEFAULT_WIDTH = 150
+
 export function ProductsCarouselCard({
   product,
   shopId,
   onProductAddedToBundle,
   onProductRemovedFromBundle,
+  fixedWidth,
 }: {
   product: ProductsCarouselProduct
   shopId: string
@@ -35,6 +38,7 @@ export function ProductsCarouselCard({
     product: ProductsCarouselProduct,
     variant: ProductsCarouselProduct['defaultVariant']
   ) => void
+  fixedWidth?: boolean
 }) {
   const [selectedVariant, setSelectedVariant] = useState(product.defaultVariant)
   const [isAddedToBundle, setIsAddedToBundle] = useState(false)
@@ -54,7 +58,11 @@ export function ProductsCarouselCard({
   ])
 
   return (
-    <Box key={product.id} maxWidth={150}>
+    <Box
+      key={product.id}
+      flex={fixedWidth ? undefined : 1}
+      maxWidth={fixedWidth ? CAROUSEL_CARD_DEFAULT_WIDTH : undefined}
+    >
       <ProductCard
         product={product}
         shopId={shopId}

--- a/packages/shop-minis-ui-extensions/src/extensions/bundle-products-carousel/index.tsx
+++ b/packages/shop-minis-ui-extensions/src/extensions/bundle-products-carousel/index.tsx
@@ -1,5 +1,6 @@
 import {Box, Text, ScreenWidthContainer} from '@shopify/shop-minis-platform-sdk'
 import {ScrollView} from 'react-native'
+import {PropsWithChildren} from 'react'
 
 import {
   ProductsCarouselCard,
@@ -10,10 +11,10 @@ import {
 export function BundleProductsCarousel({
   products,
   shopId,
+  subtitle,
   onProductAddedToBundle,
   onProductRemovedFromBundle,
   title = 'Bundle and Save',
-  subtitle,
 }: {
   products: ProductsCarouselProduct[]
   shopId: string
@@ -28,6 +29,8 @@ export function BundleProductsCarousel({
   title?: string
   subtitle?: string
 }) {
+  const cardsShouldScroll = products.length > 2 // 1 or 2 items fit in the screen width, so no need to scroll
+
   return (
     <Box marginTop="xs">
       <Text variant="bodyTitleLarge">{title}</Text>
@@ -37,8 +40,14 @@ export function BundleProductsCarousel({
         </Text>
       ) : null}
       <ScreenWidthContainer>
-        <ScrollView horizontal>
-          <Box flexDirection="row" gap="xs" marginLeft="gutter">
+        <CardsContainer scrollable={cardsShouldScroll}>
+          <Box
+            flexDirection="row"
+            gap="xs"
+            marginLeft="gutter"
+            marginRight={cardsShouldScroll ? 'none' : 'gutter'}
+            marginTop="xxs"
+          >
             {products.map(product => (
               <ProductsCarouselCard
                 key={product.id}
@@ -46,11 +55,18 @@ export function BundleProductsCarousel({
                 onProductAddedToBundle={onProductAddedToBundle}
                 onProductRemovedFromBundle={onProductRemovedFromBundle}
                 shopId={shopId}
+                fixedWidth={products.length !== 2} // when we have two products each card dynamically takes 50% width
               />
             ))}
           </Box>
-        </ScrollView>
+        </CardsContainer>
       </ScreenWidthContainer>
     </Box>
   )
 }
+
+const CardsContainer = ({
+  children,
+  scrollable,
+}: PropsWithChildren<{scrollable?: boolean}>) =>
+  scrollable ? <ScrollView horizontal>{children}</ScrollView> : <>{children}</>


### PR DESCRIPTION
## Summary

Implements the following adjustments to the products bundle carousel

- Add margin between product cards and carousel title
- Do not scroll horizontally if we have 1 or 2 items
- Take full width when there are 2 items

## TODO

We still need to improve the UI, specially when there is a single item in the carousel.

## Screenshots

### 1 item

![1 item](https://github.com/user-attachments/assets/484f32cf-319e-4f0d-8e42-9826b7fcf8c0)

### 2 items

![2 items](https://github.com/user-attachments/assets/bc980909-c5c0-4cd5-84e6-4e5142da6c9e)

### 3 or more items

![4 items](https://github.com/user-attachments/assets/d2ce2cc2-21b9-4a15-904d-004c9aa2e33f)
![4 items 2](https://github.com/user-attachments/assets/f02d61d0-cb56-4150-a0c1-158d1e25f3ee)





