### PR TITLE
Allow duplicate product ids in bundle products carousel

### DIFF
--- a/packages/shop-minis-ui-extensions/src/extensions/bundle-products-carousel/index.tsx
+++ b/packages/shop-minis-ui-extensions/src/extensions/bundle-products-carousel/index.tsx
@@ -54,9 +54,10 @@ export function BundleProductsCarousel({
               marginRight={cardsShouldScroll ? 'none' : 'gutter'}
               marginTop="xxs"
             >
-              {products.map(product => (
+              {products.map((product, index) => (
                 <ProductsCarouselCard
-                  key={product.id}
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={`${product.id}-${index}`}
                   product={product}
                   onProductAddedToBundle={onProductAddedToBundle}
                   onProductRemovedFromBundle={onProductRemovedFromBundle}


### PR DESCRIPTION
## Description

The same product can appear multiple times in the bundle products carousel. This PR updates the `key` prop to not assume that the product ids are unique within the carousel.

## Testing Instructions

<!-- Provide detailed instructions on how to test the changes made by this PR. -->
1. Pass in a list of products with duplicate ids to the extension. There should be no warning.

## Checklist

<!-- Please ensure that the following tasks are completed before submitting your PR. -->
- [x] I have read and understood the [Contribution Guidelines](../../docs/CONTRIBUTING.md).
- [x] I have followed the [Code Guidelines](../../docs/CODE_GUIDELINES.md).

## Reviewer Checklist

<!-- For reviewers to ensure that all necessary aspects have been covered. -->
- [ ] Code follows the project's coding standards.
- [ ] Documentation has been added or updated.
- [ ] Visual changes have been reviewed and approved by the UX team.
- [ ] No breaking changes or backward compatibility issues.
