### PR TITLE
Remove the Minis SDK as peer dependency

### DIFF
--- a/packages/shop-minis-ui-extensions/package.json
+++ b/packages/shop-minis-ui-extensions/package.json
@@ -14,7 +14,6 @@
   "licenseFilename": "LICENSE.md",
   "peerDependencies": {
     "@react-navigation/native": "*",
-    "@shopify/shop-minis-platform-sdk": "*",
     "lodash": "*",
     "react": "*",
     "react-native": "*",
@@ -25,9 +24,6 @@
   },
   "peerDependenciesMeta": {
     "@react-navigation/native": {
-      "optional": true
-    },
-    "@shopify/shop-minis-platform-sdk": {
       "optional": true
     },
     "lodash": {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes introduced by this PR. -->

The `@shopify/shop-minis-ui-extensions` package having `@shopify/shop-minis-platform-sdk` as a peer dependency is unnecessary because `@shopify/shop-minis-runtime` already has `@shopify/shop-minis-platform-sdk` as a peer dependency.
